### PR TITLE
chore:updated to 2.1.0 & updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Otterscan
 Otterscan DAppNodePackage
 
-https://github.com/wmitsuda/otterscan
+https://github.com/otterscan/otterscan

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,9 +1,9 @@
 {
   "name": "otterscan.public.dappnode.eth",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "shortDescription": "A blazingly fast, local, Ethereum block explorer built on top of Erigon",
   "description": "A blazingly fast, local, Ethereum block explorer built on top of Erigon",
-  "upstreamVersion": "v1.32.0",
+  "upstreamVersion": "v2.1.0",
   "upstreamRepo": "otterscan/otterscan",
   "upstreamArg": "UPSTREAM_VERSION",
   "type": "service",
@@ -31,7 +31,6 @@
     }
   ],
   "mainService": "otterscan",
-  
   "license": "GLP-3.0",
   "repository": {
     "type": "git",

--- a/getting-started.md
+++ b/getting-started.md
@@ -1,5 +1,7 @@
 ## Otterscan, a An open-source, fast, local, laptop-friendly Ethereum block explorer.
- 
+
+*Note: Even though this package contains the latest version of Otterscan, it doesn't include the new OTS2 API enabling some of the newest features.*
+*This package relies on the Erigon package maintained by dappnode, which doesn't include the OTS2 API yet.*
  
 ### Erigon settings
 When running erigon, make sure to enable the erigon, ots, eth APIs in addition to whatever cli options you are using to start erigon. It should at least look like this `--http.api "eth,erigon,ots,<your-other-apis>"`

--- a/releases.json
+++ b/releases.json
@@ -22,5 +22,11 @@
     "uploadedTo": {
       "dappnode": "Mon, 28 Aug 2023 10:49:24 GMT"
     }
+  },
+  "0.2.3": {
+    "hash": "/ipfs/QmWDux1EGMiwY73bjvk8n7toEraA2qSH8w6BdHqUiCqWtr",
+    "uploadedTo": {
+      "dappnode": "Fri, 03 Nov 2023 01:43:03 GMT"
+    }
   }
 }


### PR DESCRIPTION
updated to v2.1.0
as long as OTS2 isn't in production Erigon, it won't be enabled on the package as it is a requirement. 