### PR TITLE
Upgrade dappnode Otterscan to latest version and fix bug

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,14 +1,14 @@
 {
   "name": "otterscan.public.dappnode.eth",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "shortDescription": "A blazingly fast, local, Ethereum block explorer built on top of Erigon",
   "description": "A blazingly fast, local, Ethereum block explorer built on top of Erigon",
-  "upstreamVersion": "v2.5.0",
+  "upstreamVersion": "v2.8.0",
   "upstreamRepo": "otterscan/otterscan",
   "upstreamArg": "UPSTREAM_VERSION",
   "type": "service",
   "dependencies": {
-    "erigon.dnp.dappnode.eth": "^0.1.43"
+    "erigon.dnp.dappnode.eth": "^0.1.44"
   },
   "categories": ["Developer tools"],
   "architectures": ["linux/amd64"],
@@ -19,7 +19,7 @@
   ],
   "links": {
     "homepage": "https://github.com/otterscan/otterscan",
-    "ui": "http://scanner.otterscan.public.dappnode"
+    "ui": "http://otterscan.public.dappnode"
   },
   "exposable": [
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
-version: "3.4"
+version: "3.5"
 services:
-  scanner:
+  otterscan:
     build:
       context: .
       args:
-        UPSTREAM_VERSION: v2.5.0
+        UPSTREAM_VERSION: v2.8.0
     environment:
       ERIGON_URL: "http://erigon.dappnode:8545"
       BEACON_API_URL: ""


### PR DESCRIPTION
- Upgrade dappnode Otterscan version to 2.8.0
- Fix Dappnode HTTPs Portal bug when try to expose services